### PR TITLE
Add web search configuration option

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -23,6 +23,7 @@ var apiKey = getQueryParam('api_key');
 var baseUrl = getQueryParam('base_url');
 var model = getQueryParam('model');
 var systemMessage = getQueryParam('system_message');
+var webSearchEnabled = getQueryParam('web_search_enabled');
 
 // Get return_to for emulator support (falls back to pebblejs://close# for real hardware)
 var returnTo = getQueryParam('return_to') || 'pebblejs://close#';
@@ -39,6 +40,7 @@ document.addEventListener('DOMContentLoaded', function() {
   document.getElementById('base-url').value = baseUrl || defaults.base_url;
   document.getElementById('model').value = model || defaults.model;
   document.getElementById('system-message').value = systemMessage || defaults.system_message;
+  document.getElementById('web-search').checked = webSearchEnabled === 'true';
 
   // Function to toggle advanced fields visibility
   function toggleAdvancedFields() {
@@ -60,7 +62,8 @@ document.addEventListener('DOMContentLoaded', function() {
       api_key: apiKeyInput.value.trim(),
       base_url: document.getElementById('base-url').value.trim(),
       model: document.getElementById('model').value.trim(),
-      system_message: document.getElementById('system-message').value.trim()
+      system_message: document.getElementById('system-message').value.trim(),
+      web_search_enabled: document.getElementById('web-search').checked.toString()
     };
 
     // Send settings back to Pebble (works for both emulator and real hardware)
@@ -75,6 +78,7 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('base-url').value = defaults.base_url;
     document.getElementById('model').value = defaults.model;
     document.getElementById('system-message').value = defaults.system_message;
+    document.getElementById('web-search').checked = false;
 
     // Toggle advanced fields visibility
     toggleAdvancedFields();
@@ -84,7 +88,8 @@ document.addEventListener('DOMContentLoaded', function() {
       api_key: '',
       base_url: defaults.base_url,
       model: defaults.model,
-      system_message: defaults.system_message
+      system_message: defaults.system_message,
+      web_search_enabled: 'false'
     };
 
     var url = returnTo + encodeURIComponent(JSON.stringify(settings));

--- a/config/index.html
+++ b/config/index.html
@@ -42,6 +42,10 @@
       <td><label for="system-message">System Message</label></td>
       <td><textarea id="system-message" rows="6" placeholder="System message for Claude"></textarea></td>
     </tr>
+    <tr class="advanced-field">
+      <td><label for="web-search">Enable Web Search</label></td>
+      <td><input type="checkbox" id="web-search"></td>
+    </tr>
   </table>
 
   <button id="save-button">Save</button>

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -27,6 +27,7 @@ function streamClaudeResponse(messages) {
   var baseUrl = localStorage.getItem('base_url') || 'https://api.anthropic.com/v1/messages';
   var model = localStorage.getItem('model') || 'claude-haiku-4-5';
   var systemMessage = localStorage.getItem('system_message') || "You're running on a Pebble smartwatch. Please respond in plain text without any formatting, keeping your responses within 1-3 sentences.";
+  var webSearchEnabled = localStorage.getItem('web_search_enabled') === 'true';
 
   if (!apiKey) {
     console.log('No API key configured');
@@ -105,6 +106,15 @@ function streamClaudeResponse(messages) {
     requestBody.system = systemMessage;
   }
 
+  // Add web search tool if enabled
+  if (webSearchEnabled) {
+    requestBody.tools = [{
+      type: 'web_search_20250305',
+      name: 'web_search',
+      max_uses: 5
+    }];
+  }
+
   console.log('Request body: ' + JSON.stringify(requestBody));
   xhr.send(JSON.stringify(requestBody));
 }
@@ -146,6 +156,7 @@ Pebble.addEventListener('showConfiguration', function () {
   var baseUrl = localStorage.getItem('base_url') || '';
   var model = localStorage.getItem('model') || '';
   var systemMessage = localStorage.getItem('system_message') || '';
+  var webSearchEnabled = localStorage.getItem('web_search_enabled') || 'false';
 
   // Build configuration URL
   var url = 'https://breitburg.github.io/claude-for-pebble/config/';
@@ -153,6 +164,7 @@ Pebble.addEventListener('showConfiguration', function () {
   url += '&base_url=' + encodeURIComponent(baseUrl);
   url += '&model=' + encodeURIComponent(model);
   url += '&system_message=' + encodeURIComponent(systemMessage);
+  url += '&web_search_enabled=' + encodeURIComponent(webSearchEnabled);
 
   console.log('Opening configuration page: ' + url);
   Pebble.openURL(url);
@@ -165,7 +177,7 @@ Pebble.addEventListener('webviewclosed', function (e) {
     console.log('Settings received: ' + JSON.stringify(settings));
 
     // Save or clear settings in local storage
-    var keys = ['api_key', 'base_url', 'model', 'system_message'];
+    var keys = ['api_key', 'base_url', 'model', 'system_message', 'web_search_enabled'];
     keys.forEach(function(key) {
       if (settings[key] && settings[key].trim() !== '') {
         localStorage.setItem(key, settings[key]);


### PR DESCRIPTION
Added web search checkbox to the configuration webpage and integrated it with the Anthropic API request. When enabled, the web search tool is automatically included in API requests using the proper Anthropic web_search_20250305 tool definition with max_uses set to 5.

Changes:
- Added "Enable Web Search" checkbox to config UI (config/index.html)
- Updated config handler to save/load web_search_enabled setting (config/config.js)
- Modified API request to include web search tool when enabled (src/pkjs/index.js)
- Implemented proper localStorage persistence for the setting

Fixes #2 